### PR TITLE
Add `limit` when selecting

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -104,7 +104,8 @@ class Db {
     const result = this.db.commandSync('select', {
       table: this.config.name,
       match_columns: columns.join(','),
-      query: query
+      query: query,
+      limit: 100 // TODO: More than 100 cases
     })[0]
     const count = result.shift()[0]
     const keys = result.shift().slice(2).map((k) => k[0])


### PR DESCRIPTION
Because only 10 defaults can be acquired